### PR TITLE
Fixed publish info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,4 +14,8 @@ publishArtifact in (Compile, packageDoc) := false
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".rgcredentials")
 
-publishTo := Some("ReportGrid Nexus" at "http://devci01.reportgrid.com:8081/content/repositories/snapshots")
+publishTo <<= (version) { version: String =>
+  val nexus = "http://nexus.reportgrid.com/content/repositories/"
+  if (version.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus+"snapshots/") 
+  else                                   Some("releases"  at nexus+"releases/")
+},


### PR DESCRIPTION
The current settings in gll-combinators don't match up with the credentials, which is why it fails. This update should bring that in line as well as properly handle SNAPSHOT vs release versions.
