### PR TITLE
Computation of the FIRST set for ?-combinator

### DIFF
--- a/src/main/scala/com/codecommit/gll/Parsers.scala
+++ b/src/main/scala/com/codecommit/gll/Parsers.scala
@@ -291,7 +291,10 @@ trait Parsers {
     def +(sep: Parser[_]) = this ~ (sep ~> this).* ^^ { _ :: _ }
     
     def ?(): Parser[Option[R]] = new NonTerminalParser[Option[R]] {
-      def computeFirst(seen: Set[Parser[Any]]) = Some(Set[Option[Char]](None))
+      def computeFirst(seen: Set[Parser[Any]]) = self.computeFirst(seen) match {
+        case Some(set) => Some(set + None)
+        case None => Some(Set[Option[Char]](None))
+      }
       
       def chain(t: Trampoline, in: LineStream)(f: Result[Option[R]] => Unit) {
         f(Success(None, in))

--- a/src/test/scala/CompoundSpecs.scala
+++ b/src/test/scala/CompoundSpecs.scala
@@ -494,6 +494,26 @@ object CompoundSpecs extends Specification
         case Success(None, LineStream()) #:: SNil => ok
       }
     }
+    
+    "repeat 1..n times with optional parser as first component" in {
+      val p = ("-".? ~> "1")+
+      
+      p("11") must beLike {
+        case Success(List("1", "1"), LineStream()) #:: SNil => ok
+      }
+      p("-11") must beLike {
+        case Success(List("1", "1"), LineStream()) #:: SNil => ok
+      }
+      p("1-1") must beLike {
+        case Success(List("1", "1"), LineStream()) #:: SNil => ok
+      }
+      p("-1-1") must beLike {
+        case Success(List("1", "1"), LineStream()) #:: SNil => ok
+      }
+      p("1-1-1") must beLike {
+        case Success(List("1", "1", "1"), LineStream()) #:: SNil => ok
+      }
+    }
   }
   
   "monadic parsers" should {


### PR DESCRIPTION
There has been a problem using the ?-combinator inside the +-combinator, since the FIRST set of ? was always empty and thus the +-combinator has not been applied multiple times.

The parser

```
("-".? ~ "1").+
```

did recognize strings like `11` and `1-1` but _not_ `-11`, `-1-1` and `1-1-1`.

After fixing the computation of the FIRST-set all strings are recognized.
